### PR TITLE
Exhibition 테이블 뷰에서 아이템 선택 시 Detail View 로 넘어가는 과정 구현

### DIFF
--- a/own-exhibition.xcodeproj/project.pbxproj
+++ b/own-exhibition.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		DA170D442910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D432910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift */; };
 		DA170D462910EB2100BFC7B1 /* ExhibitionDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA170D452910EB2100BFC7B1 /* ExhibitionDetail.storyboard */; };
 		DA170D482910EB3600BFC7B1 /* ExhibitionDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D472910EB3600BFC7B1 /* ExhibitionDetailViewController.swift */; };
+		DA170D4A29111B5300BFC7B1 /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D4929111B5300BFC7B1 /* HomeCoordinator.swift */; };
+		DA170D4C291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D4B291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift */; };
 		E805F2AC2901528000D75FA3 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805F2AB2901528000D75FA3 /* HomeViewModel.swift */; };
 		E805F2AE290152A200D75FA3 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805F2AD290152A200D75FA3 /* ViewModelType.swift */; };
 		E805F2B0290159DA00D75FA3 /* Instantiatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805F2AF290159DA00D75FA3 /* Instantiatable.swift */; };
@@ -68,6 +70,8 @@
 		DA170D432910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionDetailViewModel.swift; sourceTree = "<group>"; };
 		DA170D452910EB2100BFC7B1 /* ExhibitionDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ExhibitionDetail.storyboard; sourceTree = "<group>"; };
 		DA170D472910EB3600BFC7B1 /* ExhibitionDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionDetailViewController.swift; sourceTree = "<group>"; };
+		DA170D4929111B5300BFC7B1 /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
+		DA170D4B291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionDetailCoordinator.swift; sourceTree = "<group>"; };
 		E5E722FB0506808F9D489C0D /* Pods-own-exhibition.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-own-exhibition.release.xcconfig"; path = "Target Support Files/Pods-own-exhibition/Pods-own-exhibition.release.xcconfig"; sourceTree = "<group>"; };
 		E5EC47743B90C6D64BDFE17B /* Pods_own_exhibitionTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_own_exhibitionTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E805F2AB2901528000D75FA3 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
@@ -266,6 +270,7 @@
 				E8A1ADDE28EBDD1600A360FA /* Home.storyboard */,
 				E8A1ADDC28EBDD1600A360FA /* HomeViewController.swift */,
 				E805F2AB2901528000D75FA3 /* HomeViewModel.swift */,
+				DA170D4929111B5300BFC7B1 /* HomeCoordinator.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -290,6 +295,7 @@
 				DA170D452910EB2100BFC7B1 /* ExhibitionDetail.storyboard */,
 				DA170D472910EB3600BFC7B1 /* ExhibitionDetailViewController.swift */,
 				DA170D432910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift */,
+				DA170D4B291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift */,
 			);
 			path = ExhibitionDetail;
 			sourceTree = "<group>";
@@ -620,6 +626,7 @@
 				E805F2C72901AAFC00D75FA3 /* Reusable.swift in Sources */,
 				DA170D442910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift in Sources */,
 				E8A1ADDD28EBDD1600A360FA /* HomeViewController.swift in Sources */,
+				DA170D4A29111B5300BFC7B1 /* HomeCoordinator.swift in Sources */,
 				E8A1ADD928EBDD1600A360FA /* AppDelegate.swift in Sources */,
 				DA170D482910EB3600BFC7B1 /* ExhibitionDetailViewController.swift in Sources */,
 				E805F2C22901977300D75FA3 /* ExhibitionTableViewCell.swift in Sources */,
@@ -630,6 +637,7 @@
 				E8A1ADDB28EBDD1600A360FA /* SceneDelegate.swift in Sources */,
 				68A26165290DB4D10036DF42 /* Extension_UIView.swift in Sources */,
 				E805F2AE290152A200D75FA3 /* ViewModelType.swift in Sources */,
+				DA170D4C291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift in Sources */,
 				E805F2BA2901944800D75FA3 /* Exhibition.swift in Sources */,
 				E805F2AC2901528000D75FA3 /* HomeViewModel.swift in Sources */,
 				68B54475290D2BB500A9F71A /* MyPageViewModel.swift in Sources */,

--- a/own-exhibition.xcodeproj/project.pbxproj
+++ b/own-exhibition.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		DA170D482910EB3600BFC7B1 /* ExhibitionDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D472910EB3600BFC7B1 /* ExhibitionDetailViewController.swift */; };
 		DA170D4A29111B5300BFC7B1 /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D4929111B5300BFC7B1 /* HomeCoordinator.swift */; };
 		DA170D4C291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D4B291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift */; };
+		DA41F6DF29100FFB008ED455 /* ExhibitionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA41F6DE29100FFB008ED455 /* ExhibitionRepository.swift */; };
 		E805F2AC2901528000D75FA3 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805F2AB2901528000D75FA3 /* HomeViewModel.swift */; };
 		E805F2AE290152A200D75FA3 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805F2AD290152A200D75FA3 /* ViewModelType.swift */; };
 		E805F2B0290159DA00D75FA3 /* Instantiatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805F2AF290159DA00D75FA3 /* Instantiatable.swift */; };
@@ -72,6 +73,7 @@
 		DA170D472910EB3600BFC7B1 /* ExhibitionDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionDetailViewController.swift; sourceTree = "<group>"; };
 		DA170D4929111B5300BFC7B1 /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		DA170D4B291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionDetailCoordinator.swift; sourceTree = "<group>"; };
+		DA41F6DE29100FFB008ED455 /* ExhibitionRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionRepository.swift; sourceTree = "<group>"; };
 		E5E722FB0506808F9D489C0D /* Pods-own-exhibition.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-own-exhibition.release.xcconfig"; path = "Target Support Files/Pods-own-exhibition/Pods-own-exhibition.release.xcconfig"; sourceTree = "<group>"; };
 		E5EC47743B90C6D64BDFE17B /* Pods_own_exhibitionTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_own_exhibitionTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E805F2AB2901528000D75FA3 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
@@ -325,6 +327,7 @@
 		E8BABA5828FE4FF4009482E4 /* Repositories */ = {
 			isa = PBXGroup;
 			children = (
+				DA41F6DE29100FFB008ED455 /* ExhibitionRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -640,6 +643,7 @@
 				DA170D4C291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift in Sources */,
 				E805F2BA2901944800D75FA3 /* Exhibition.swift in Sources */,
 				E805F2AC2901528000D75FA3 /* HomeViewModel.swift in Sources */,
+				DA41F6DF29100FFB008ED455 /* ExhibitionRepository.swift in Sources */,
 				68B54475290D2BB500A9F71A /* MyPageViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/own-exhibition.xcodeproj/project.pbxproj
+++ b/own-exhibition.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		68B54475290D2BB500A9F71A /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B54474290D2BB500A9F71A /* MyPageViewModel.swift */; };
 		9B4ED1BD7AE3557D41B06928 /* Pods_own_exhibition_own_exhibitionUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6CB026F896B3ABD4A15C0AE7 /* Pods_own_exhibition_own_exhibitionUITests.framework */; };
 		CDF791247FA081D1DD955951 /* Pods_own_exhibition.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED7475A1327DEDCAB313564A /* Pods_own_exhibition.framework */; };
+		DA170D442910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D432910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift */; };
+		DA170D462910EB2100BFC7B1 /* ExhibitionDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA170D452910EB2100BFC7B1 /* ExhibitionDetail.storyboard */; };
+		DA170D482910EB3600BFC7B1 /* ExhibitionDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D472910EB3600BFC7B1 /* ExhibitionDetailViewController.swift */; };
 		E805F2AC2901528000D75FA3 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805F2AB2901528000D75FA3 /* HomeViewModel.swift */; };
 		E805F2AE290152A200D75FA3 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805F2AD290152A200D75FA3 /* ViewModelType.swift */; };
 		E805F2B0290159DA00D75FA3 /* Instantiatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805F2AF290159DA00D75FA3 /* Instantiatable.swift */; };
@@ -62,6 +65,9 @@
 		B1C0DEA57AE1F31E20FFB3F8 /* Pods-own-exhibition-own-exhibitionUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-own-exhibition-own-exhibitionUITests.release.xcconfig"; path = "Target Support Files/Pods-own-exhibition-own-exhibitionUITests/Pods-own-exhibition-own-exhibitionUITests.release.xcconfig"; sourceTree = "<group>"; };
 		B34BA56686DEFE9E50EACE4C /* Pods-own-exhibition-own-exhibitionUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-own-exhibition-own-exhibitionUITests.debug.xcconfig"; path = "Target Support Files/Pods-own-exhibition-own-exhibitionUITests/Pods-own-exhibition-own-exhibitionUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		D6E8EBDF715CB340B3AEBDF3 /* Pods-own-exhibitionTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-own-exhibitionTests.debug.xcconfig"; path = "Target Support Files/Pods-own-exhibitionTests/Pods-own-exhibitionTests.debug.xcconfig"; sourceTree = "<group>"; };
+		DA170D432910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionDetailViewModel.swift; sourceTree = "<group>"; };
+		DA170D452910EB2100BFC7B1 /* ExhibitionDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ExhibitionDetail.storyboard; sourceTree = "<group>"; };
+		DA170D472910EB3600BFC7B1 /* ExhibitionDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionDetailViewController.swift; sourceTree = "<group>"; };
 		E5E722FB0506808F9D489C0D /* Pods-own-exhibition.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-own-exhibition.release.xcconfig"; path = "Target Support Files/Pods-own-exhibition/Pods-own-exhibition.release.xcconfig"; sourceTree = "<group>"; };
 		E5EC47743B90C6D64BDFE17B /* Pods_own_exhibitionTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_own_exhibitionTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E805F2AB2901528000D75FA3 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
@@ -281,6 +287,9 @@
 		E8BABA5428FE4E4B009482E4 /* ExhibitionDetail */ = {
 			isa = PBXGroup;
 			children = (
+				DA170D452910EB2100BFC7B1 /* ExhibitionDetail.storyboard */,
+				DA170D472910EB3600BFC7B1 /* ExhibitionDetailViewController.swift */,
+				DA170D432910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift */,
 			);
 			path = ExhibitionDetail;
 			sourceTree = "<group>";
@@ -475,6 +484,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA170D462910EB2100BFC7B1 /* ExhibitionDetail.storyboard in Resources */,
 				E8A1ADE528EBDD1800A360FA /* LaunchScreen.storyboard in Resources */,
 				E8A1ADE228EBDD1800A360FA /* Assets.xcassets in Resources */,
 				E805F2C32901977300D75FA3 /* ExhibitionTableViewCell.xib in Resources */,
@@ -608,8 +618,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				E805F2C72901AAFC00D75FA3 /* Reusable.swift in Sources */,
+				DA170D442910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift in Sources */,
 				E8A1ADDD28EBDD1600A360FA /* HomeViewController.swift in Sources */,
 				E8A1ADD928EBDD1600A360FA /* AppDelegate.swift in Sources */,
+				DA170D482910EB3600BFC7B1 /* ExhibitionDetailViewController.swift in Sources */,
 				E805F2C22901977300D75FA3 /* ExhibitionTableViewCell.swift in Sources */,
 				E805F2BE2901959E00D75FA3 /* GeoCoordinate.swift in Sources */,
 				68B54473290D2BA000A9F71A /* MyPageViewController.swift in Sources */,

--- a/own-exhibition/Presentation/Common/TabBarController/MainTabBarController.swift
+++ b/own-exhibition/Presentation/Common/TabBarController/MainTabBarController.swift
@@ -12,13 +12,14 @@ final class MainTabBarController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let homeVC = HomeViewController.instantiate(withStoryboardName: "Home")
-        let homeTabBarItem = UITabBarItem.init(
+        let homeNavigationController: UINavigationController = .init()
+        homeNavigationController.tabBarItem = .init(
             title: "홈",
             image: UIImage.init(systemName: "house"),
             selectedImage: UIImage.init(systemName: "house.fill")
         )
-        homeVC.tabBarItem = homeTabBarItem
+        let homeCoordinator: HomeCoordinator = .init(navigationController: homeNavigationController)
+        homeCoordinator.start()
         
         let myPageVC = MyPageViewController.instantiate(withStoryboardName: "MyPage")
         let myPageTabBarItem = UITabBarItem.init(
@@ -28,8 +29,7 @@ final class MainTabBarController: UITabBarController {
         )
         myPageVC.tabBarItem = myPageTabBarItem
         
-        self.viewControllers = [homeVC, myPageVC]
-        
+        self.viewControllers = [homeNavigationController, myPageVC]
         
         self.tabBar.backgroundColor = .systemGray6
     }

--- a/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetail.storyboard
+++ b/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetail.storyboard
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Exhibition Detail View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="ExhibitionDetailViewController" id="Y6W-OH-hqX" customClass="ExhibitionDetailViewController" customModule="own_exhibition" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="138" y="4"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailCoordinator.swift
+++ b/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailCoordinator.swift
@@ -16,10 +16,10 @@ final class ExhibitionDetailCoordinator {
         self.navigationController = navigationController
     }
     
-    func start() {
+    func start(with exhibition: Exhibition) {
         let exhibitionDetailVC: ExhibitionDetailViewController = .instantiate(withStoryboardName: storyboardName)
-        let exhibitionDetailVM: ExhibitionDetailViewModel = .init()
+        let exhibitionDetailVM: ExhibitionDetailViewModel = .init(exhibition: exhibition)
         exhibitionDetailVC.setViewModel(by: exhibitionDetailVM)
-        navigationController.pushViewController(exhibitionDetailVC, animated: false)
+        navigationController.pushViewController(exhibitionDetailVC, animated: true)
     }
 }

--- a/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailCoordinator.swift
+++ b/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailCoordinator.swift
@@ -1,0 +1,25 @@
+//
+//  ExhibitionDetailCoordinator.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/11/01.
+//
+
+import UIKit
+
+final class ExhibitionDetailCoordinator {
+    
+    private let navigationController: UINavigationController
+    private let storyboardName: String = "ExhibitionDetail"
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        let exhibitionDetailVC: ExhibitionDetailViewController = .instantiate(withStoryboardName: storyboardName)
+        let exhibitionDetailVM: ExhibitionDetailViewModel = .init()
+        exhibitionDetailVC.setViewModel(by: exhibitionDetailVM)
+        navigationController.pushViewController(exhibitionDetailVC, animated: false)
+    }
+}

--- a/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailViewController.swift
+++ b/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ExhibitionDetailViewController.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/11/01.
+//
+
+import RxSwift
+
+final class ExhibitionDetailViewController: UIViewController {
+    
+    private let disposeBag = DisposeBag.init()
+    
+    var viewModel: ExhibitionDetailViewModel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        bindViewModel()
+    }
+    
+    private func bindViewModel() {
+        let input = ExhibitionDetailViewModel.Input.init()
+        let output = viewModel.transform(input: input)
+    }
+}

--- a/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailViewController.swift
+++ b/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailViewController.swift
@@ -11,7 +11,7 @@ final class ExhibitionDetailViewController: UIViewController {
     
     private let disposeBag = DisposeBag.init()
     
-    var viewModel: ExhibitionDetailViewModel!
+    private var viewModel: ExhibitionDetailViewModel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,5 +21,9 @@ final class ExhibitionDetailViewController: UIViewController {
     private func bindViewModel() {
         let input = ExhibitionDetailViewModel.Input.init()
         let output = viewModel.transform(input: input)
+    }
+    
+    func setViewModel(by viewModel: ExhibitionDetailViewModel) {
+        self.viewModel = viewModel
     }
 }

--- a/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailViewModel.swift
+++ b/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailViewModel.swift
@@ -17,6 +17,12 @@ final class ExhibitionDetailViewModel: ViewModelType {
         
     }
     
+    private let exhibition: Exhibition
+    
+    init(exhibition: Exhibition) {
+        self.exhibition = exhibition
+    }
+    
     func transform(input: Input) -> Output {
         return .init()
     }

--- a/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailViewModel.swift
+++ b/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailViewModel.swift
@@ -1,0 +1,23 @@
+//
+//  ExhibitionDetailViewModel.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/11/01.
+//
+
+import RxSwift
+
+final class ExhibitionDetailViewModel: ViewModelType {
+    
+    struct Input {
+        
+    }
+    
+    struct Output {
+        
+    }
+    
+    func transform(input: Input) -> Output {
+        return .init()
+    }
+}

--- a/own-exhibition/Presentation/Scenes/Home/HomeCoordinator.swift
+++ b/own-exhibition/Presentation/Scenes/Home/HomeCoordinator.swift
@@ -1,0 +1,30 @@
+//
+//  HomeCoordinator.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/11/01.
+//
+
+import UIKit
+
+final class HomeCoordinator {
+    
+    private let navigationController: UINavigationController
+    private let storyboardName: String = "Home"
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        let homeVC: HomeViewController = .instantiate(withStoryboardName: storyboardName)
+        let homeVM: HomeViewModel = .init()
+        homeVC.setViewModel(by: homeVM)
+        navigationController.pushViewController(homeVC, animated: false)
+    }
+    
+    func toDetail() {
+        let exhibitionDetailCoordinator: ExhibitionDetailCoordinator = .init(navigationController: navigationController)
+        exhibitionDetailCoordinator.start()
+    }
+}

--- a/own-exhibition/Presentation/Scenes/Home/HomeCoordinator.swift
+++ b/own-exhibition/Presentation/Scenes/Home/HomeCoordinator.swift
@@ -18,13 +18,13 @@ final class HomeCoordinator {
     
     func start() {
         let homeVC: HomeViewController = .instantiate(withStoryboardName: storyboardName)
-        let homeVM: HomeViewModel = .init()
+        let homeVM: HomeViewModel = .init(coordinator: self, exhibitionRepository: .init())
         homeVC.setViewModel(by: homeVM)
         navigationController.pushViewController(homeVC, animated: false)
     }
     
-    func toDetail() {
+    func toDetail(with exhibition: Exhibition) {
         let exhibitionDetailCoordinator: ExhibitionDetailCoordinator = .init(navigationController: navigationController)
-        exhibitionDetailCoordinator.start()
+        exhibitionDetailCoordinator.start(with: exhibition)
     }
 }

--- a/own-exhibition/Presentation/Scenes/Home/HomeViewController.swift
+++ b/own-exhibition/Presentation/Scenes/Home/HomeViewController.swift
@@ -23,7 +23,13 @@ final class HomeViewController: UIViewController {
     }
     
     private func bindViewModel() {
-        let input = HomeViewModel.Input.init()
+        let viewWillAppear = self.rx.sentMessage(#selector(self.viewWillAppear(_:)))
+            .map { _ in }
+        
+        let input = HomeViewModel.Input.init(
+            viewWillAppear: viewWillAppear.asSignal(onErrorSignalWith: .empty()),
+            selection: exhibitionTableView.rx.itemSelected.asDriver()
+        )
         let output = viewModel.transform(input: input)
         
         output.exhibitions
@@ -35,6 +41,10 @@ final class HomeViewController: UIViewController {
             ) { index, exhibition, cell in
                 cell.bind(by: exhibition)
             }
+            .disposed(by: disposeBag)
+        
+        output.selectedExhibition
+            .drive()
             .disposed(by: disposeBag)
     }
     

--- a/own-exhibition/Presentation/Scenes/Home/HomeViewController.swift
+++ b/own-exhibition/Presentation/Scenes/Home/HomeViewController.swift
@@ -14,7 +14,7 @@ final class HomeViewController: UIViewController {
     
     @IBOutlet weak var exhibitionTableView: UITableView!
     
-    private var viewModel: HomeViewModel = HomeViewModel.init()
+    private var viewModel: HomeViewModel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -42,5 +42,9 @@ final class HomeViewController: UIViewController {
         let nibName = ExhibitionTableViewCell.id
         let nib = UINib.init(nibName: nibName, bundle: nil)
         exhibitionTableView.register(nib, forCellReuseIdentifier: nibName)
+    }
+    
+    func setViewModel(by viewModel: HomeViewModel) {
+        self.viewModel = viewModel
     }
 }

--- a/own-exhibition/Repositories/ExhibitionRepository.swift
+++ b/own-exhibition/Repositories/ExhibitionRepository.swift
@@ -1,0 +1,31 @@
+//
+//  ExhibitionRepository.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/10/31.
+//
+
+import RxSwift
+
+final class ExhibitionRepository {
+    
+    func getExhibitions() -> Observable<[Exhibition]> {
+        return .of([
+            .makeMock(),
+            .makeMock(),
+            .makeMock(),
+            .makeMock(),
+            .makeMock(),
+            .makeMock(),
+            .makeMock(),
+            .makeMock(),
+            .makeMock(),
+            .makeMock(),
+            .makeMock(),
+            .makeMock(),
+            .makeMock(),
+            .makeMock(),
+            .makeMock()
+        ])
+    }
+}


### PR DESCRIPTION
## 부가 설명
<!-- 필요 시 작성 -->
- 화면 전환을 '어떻게' 수행하는지 관리하는 Coordinator 추가
- 홈 화면에서 아이템 선택 시 해당 아이템을 가지고 Detail View 로 이동
  - HomeViewModel 의 `selection` input -> HomeCoordinator 의 `toDetail` 함수 호출



## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 생각해주세요!! -->

- [x] 변경 사항을 적용하고 테스트를 해봤나요?
- [x] [Code Convention](https://own-exhibition.notion.site/Code-Style-de19f16db2a544d08da60335f51c9912)을 준수했나요?
