### PR TITLE
테이블뷰로 보여줄 썸네일 이미지를 비동기적으로 가져오고 매핑하도록 구현

### DIFF
--- a/own-exhibition.xcodeproj/project.pbxproj
+++ b/own-exhibition.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		68B54475290D2BB500A9F71A /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B54474290D2BB500A9F71A /* MyPageViewModel.swift */; };
 		9B4ED1BD7AE3557D41B06928 /* Pods_own_exhibition_own_exhibitionUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6CB026F896B3ABD4A15C0AE7 /* Pods_own_exhibition_own_exhibitionUITests.framework */; };
 		CDF791247FA081D1DD955951 /* Pods_own_exhibition.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED7475A1327DEDCAB313564A /* Pods_own_exhibition.framework */; };
+		DA0A881F291D424500E9AE43 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0A881E291D424500E9AE43 /* ImageLoader.swift */; };
 		DA170D442910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D432910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift */; };
 		DA170D462910EB2100BFC7B1 /* ExhibitionDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA170D452910EB2100BFC7B1 /* ExhibitionDetail.storyboard */; };
 		DA170D482910EB3600BFC7B1 /* ExhibitionDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D472910EB3600BFC7B1 /* ExhibitionDetailViewController.swift */; };
@@ -69,6 +70,7 @@
 		B1C0DEA57AE1F31E20FFB3F8 /* Pods-own-exhibition-own-exhibitionUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-own-exhibition-own-exhibitionUITests.release.xcconfig"; path = "Target Support Files/Pods-own-exhibition-own-exhibitionUITests/Pods-own-exhibition-own-exhibitionUITests.release.xcconfig"; sourceTree = "<group>"; };
 		B34BA56686DEFE9E50EACE4C /* Pods-own-exhibition-own-exhibitionUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-own-exhibition-own-exhibitionUITests.debug.xcconfig"; path = "Target Support Files/Pods-own-exhibition-own-exhibitionUITests/Pods-own-exhibition-own-exhibitionUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		D6E8EBDF715CB340B3AEBDF3 /* Pods-own-exhibitionTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-own-exhibitionTests.debug.xcconfig"; path = "Target Support Files/Pods-own-exhibitionTests/Pods-own-exhibitionTests.debug.xcconfig"; sourceTree = "<group>"; };
+		DA0A881E291D424500E9AE43 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		DA170D432910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionDetailViewModel.swift; sourceTree = "<group>"; };
 		DA170D452910EB2100BFC7B1 /* ExhibitionDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ExhibitionDetail.storyboard; sourceTree = "<group>"; };
 		DA170D472910EB3600BFC7B1 /* ExhibitionDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionDetailViewController.swift; sourceTree = "<group>"; };
@@ -212,6 +214,7 @@
 			isa = PBXGroup;
 			children = (
 				DAAFB254291A90A0007A8DF0 /* Extensions */,
+				DA0A881E291D424500E9AE43 /* ImageLoader.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -651,6 +654,7 @@
 				E8A1ADDB28EBDD1600A360FA /* SceneDelegate.swift in Sources */,
 				68A26165290DB4D10036DF42 /* UIView+.swift in Sources */,
 				DAAFB256291A90B7007A8DF0 /* CALayer+.swift in Sources */,
+				DA0A881F291D424500E9AE43 /* ImageLoader.swift in Sources */,
 				E805F2AE290152A200D75FA3 /* ViewModelType.swift in Sources */,
 				DA170D4C291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift in Sources */,
 				E805F2BA2901944800D75FA3 /* Exhibition.swift in Sources */,

--- a/own-exhibition.xcodeproj/project.pbxproj
+++ b/own-exhibition.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		DA170D4A29111B5300BFC7B1 /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D4929111B5300BFC7B1 /* HomeCoordinator.swift */; };
 		DA170D4C291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D4B291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift */; };
 		DA41F6DF29100FFB008ED455 /* ExhibitionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA41F6DE29100FFB008ED455 /* ExhibitionRepository.swift */; };
+		DA42DD7B29226AB700094733 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA42DD7A29226AB700094733 /* UIImage+.swift */; };
 		DAAFB256291A90B7007A8DF0 /* CALayer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAFB255291A90B7007A8DF0 /* CALayer+.swift */; };
 		E805F2AC2901528000D75FA3 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805F2AB2901528000D75FA3 /* HomeViewModel.swift */; };
 		E805F2AE290152A200D75FA3 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805F2AD290152A200D75FA3 /* ViewModelType.swift */; };
@@ -77,6 +78,7 @@
 		DA170D4929111B5300BFC7B1 /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
 		DA170D4B291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionDetailCoordinator.swift; sourceTree = "<group>"; };
 		DA41F6DE29100FFB008ED455 /* ExhibitionRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionRepository.swift; sourceTree = "<group>"; };
+		DA42DD7A29226AB700094733 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		DAAFB255291A90B7007A8DF0 /* CALayer+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+.swift"; sourceTree = "<group>"; };
 		E5E722FB0506808F9D489C0D /* Pods-own-exhibition.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-own-exhibition.release.xcconfig"; path = "Target Support Files/Pods-own-exhibition/Pods-own-exhibition.release.xcconfig"; sourceTree = "<group>"; };
 		E5EC47743B90C6D64BDFE17B /* Pods_own_exhibitionTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_own_exhibitionTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -179,6 +181,7 @@
 			children = (
 				68A26164290DB4D10036DF42 /* UIView+.swift */,
 				DAAFB255291A90B7007A8DF0 /* CALayer+.swift */,
+				DA42DD7A29226AB700094733 /* UIImage+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -659,6 +662,7 @@
 				DA170D4C291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift in Sources */,
 				E805F2BA2901944800D75FA3 /* Exhibition.swift in Sources */,
 				E805F2AC2901528000D75FA3 /* HomeViewModel.swift in Sources */,
+				DA42DD7B29226AB700094733 /* UIImage+.swift in Sources */,
 				DA41F6DF29100FFB008ED455 /* ExhibitionRepository.swift in Sources */,
 				68B54475290D2BB500A9F71A /* MyPageViewModel.swift in Sources */,
 			);

--- a/own-exhibition/Presentation/Common/Cell/ExhibitionTableViewCell.swift
+++ b/own-exhibition/Presentation/Common/Cell/ExhibitionTableViewCell.swift
@@ -41,7 +41,7 @@ final class ExhibitionTableViewCell: UITableViewCell {
     }
     
     func initializeCell() {
-        thumbnailImageView.image = UIImage.init(named: "default_thumbnail")
+        thumbnailImageView.image = .defaultThumbnail
         titleLabel.text = ""
         periodLabel.text = ""
         placeLabel.text = ""
@@ -52,7 +52,7 @@ final class ExhibitionTableViewCell: UITableViewCell {
         if let thumbnailImage = thumbnailImage {
             thumbnailImageView.image = thumbnailImage
         } else {
-            thumbnailImageView.image = UIImage.init(named: "default_thumbnail")
+            thumbnailImageView.image = .defaultThumbnail
         }
     }
     

--- a/own-exhibition/Presentation/Common/Cell/ExhibitionTableViewCell.swift
+++ b/own-exhibition/Presentation/Common/Cell/ExhibitionTableViewCell.swift
@@ -23,16 +23,7 @@ final class ExhibitionTableViewCell: UITableViewCell {
         super.setSelected(selected, animated: animated)
     }
     
-    func bind(by exhibition: Exhibition) {
-        thumbnailImageView.image = {
-            if let imageUrl = URL.init(string: exhibition.thumbnailUrl),
-               let imageData = try? Data.init(contentsOf: imageUrl),
-               let thumbnail = UIImage.init(data: imageData) {
-                return thumbnail
-            } else {
-                return UIImage.init(named: "default_thumbnail")
-            }
-        }()
+    func bind(_ exhibition: Exhibition, withFetchedImage fetchedImage: @escaping (UIImage?) -> Void) {
         titleLabel.text = exhibition.title
         periodLabel.text = {
             let formatter: DateFormatter = .init()
@@ -43,5 +34,37 @@ final class ExhibitionTableViewCell: UITableViewCell {
         }()
         placeLabel.text = "장소 : \(exhibition.place)"
         descriptionLabel.text = exhibition.description
+        
+        fetchThumbnailImage(exhibition.thumbnailUrl) { image in
+            fetchedImage(image)
+        }
+    }
+    
+    func initializeCell() {
+        thumbnailImageView.image = UIImage.init(named: "default_thumbnail")
+        titleLabel.text = ""
+        periodLabel.text = ""
+        placeLabel.text = ""
+        descriptionLabel.text = ""
+    }
+    
+    func setThumbnailImage(_ thumbnailImage: UIImage?) {
+        if let thumbnailImage = thumbnailImage {
+            thumbnailImageView.image = thumbnailImage
+        } else {
+            thumbnailImageView.image = UIImage.init(named: "default_thumbnail")
+        }
+    }
+    
+    private func fetchThumbnailImage(_ url: String, completion: @escaping (UIImage?) -> Void) {
+        ImageLoader.patch(url) { result in
+            switch result {
+            case .success(let thumbnailImage):
+                completion(thumbnailImage)
+            case .failure(let error):
+                _ = error
+                completion(nil)
+            }
+        }
     }
 }

--- a/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailViewController.swift
+++ b/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailViewController.swift
@@ -42,15 +42,17 @@ final class ExhibitionDetailViewController: UIViewController {
     
     private var exhibitionBinding: Binder<Exhibition> {
         return .init(self, binding: { vc, exhibition in
-            vc.originalImageView.image = {
-                if let imageUrl = URL.init(string: exhibition.thumbnailUrl),
-                   let imageData = try? Data.init(contentsOf: imageUrl),
-                   let thumbnail = UIImage.init(data: imageData) {
-                    return thumbnail
-                } else {
-                    return UIImage.init(named: "default_thumbnail")
+            ImageLoader.patch(exhibition.thumbnailUrl) { result in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success(let image):
+                        vc.originalImageView.image = image
+                    case .failure(let error):
+                        _ = error
+                        vc.originalImageView.image = UIImage.init(named: "default_thumbnail")
+                    }
                 }
-            }()
+            }
             vc.periodLabel.text = {
                 let formatter: DateFormatter = .init()
                 formatter.dateFormat = "yyyy.MM.dd"

--- a/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailViewController.swift
+++ b/own-exhibition/Presentation/Scenes/ExhibitionDetail/ExhibitionDetailViewController.swift
@@ -49,7 +49,7 @@ final class ExhibitionDetailViewController: UIViewController {
                         vc.originalImageView.image = image
                     case .failure(let error):
                         _ = error
-                        vc.originalImageView.image = UIImage.init(named: "default_thumbnail")
+                        vc.originalImageView.image = .defaultThumbnail
                     }
                 }
             }

--- a/own-exhibition/Presentation/Scenes/Home/HomeViewController.swift
+++ b/own-exhibition/Presentation/Scenes/Home/HomeViewController.swift
@@ -39,7 +39,14 @@ final class HomeViewController: UIViewController {
                     cellType: ExhibitionTableViewCell.self
                 )
             ) { index, exhibition, cell in
-                cell.bind(by: exhibition)
+                let indexPath: IndexPath = .init(row: index, section: 0)
+                cell.initializeCell()
+                cell.bind(exhibition, withFetchedImage: { [indexPath] thumbnailImage in
+                    DispatchQueue.main.async {
+                        let currentCell = self.exhibitionTableView.cellForRow(at: indexPath) as? ExhibitionTableViewCell
+                        currentCell?.setThumbnailImage(thumbnailImage)
+                    }
+                })
             }
             .disposed(by: disposeBag)
         

--- a/own-exhibition/Utils/Extensions/UIImage+.swift
+++ b/own-exhibition/Utils/Extensions/UIImage+.swift
@@ -1,0 +1,14 @@
+//
+//  UIImage+.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/11/14.
+//
+
+import UIKit
+
+extension UIImage {
+    
+    /// Asset 에 있는 기본 썸네일 이미지입니다.
+    static let defaultThumbnail: UIImage? = .init(named: "default_thumbnail")
+}

--- a/own-exhibition/Utils/ImageLoader.swift
+++ b/own-exhibition/Utils/ImageLoader.swift
@@ -1,0 +1,59 @@
+//
+//  ImageLoader.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/11/10.
+//
+
+import UIKit
+
+enum NetworkError: Error {
+    case invalidURL
+    case invalidStatusCode
+    case nonExistentData
+}
+
+enum ImageLoaderError: Error {
+    case notImageData
+}
+
+struct ImageLoader {
+    
+    static func patch(_ url: String, _ completion: @escaping (Result<UIImage, Error>) -> Void) {
+        guard let url = URL.init(string: url) else {
+            return completion(.failure(NetworkError.invalidURL))
+        }
+        
+        patch(url, completion)
+    }
+    
+    static func patch(_ url: URL, _ completion: @escaping (Result<UIImage, Error>) -> Void) {
+        let urlRequest: URLRequest = .init(url: url)
+        patch(urlRequest, completion)
+    }
+    
+    static func patch(_ urlRequest: URLRequest, _ completion: @escaping (Result<UIImage, Error>) -> Void) {
+        URLSession.shared.dataTask(with: urlRequest) { data, urlResponse, error in
+            if let error = error {
+                return completion(.failure(error))
+            }
+            
+            guard let response = urlResponse as? HTTPURLResponse,
+                  (200..<300).contains(response.statusCode)
+            else {
+                return completion(.failure(NetworkError.invalidStatusCode))
+            }
+            
+            guard let data = data else {
+                return completion(.failure(NetworkError.nonExistentData))
+            }
+            
+            guard let image = UIImage.init(data: data) else {
+                return completion(.failure(ImageLoaderError.notImageData))
+            }
+            
+            return completion(.success(image))
+        }
+        .resume()
+    }
+}


### PR DESCRIPTION
## 부가 설명
<!-- 필요 시 작성 -->
- #9 이슈에 대한 PR
- 아직도 빠르게 스크롤 했을 때 버벅거리는 문제가 있는데, 이 문제는 이미지 용량 때문인 것 같습니다. 추후에 서버쪽에서 리사이징된 이미지를 보내줄 수 있을때 제대로 작동하는지 테스트 해보면 될듯합니다.
- ImageLoader 에 cache 적용 작업 진행중입니당


## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->
### Cell 에 데이터를 세팅하는 과정
```mermaid
flowchart TB
    A[Reusable Cell 생성] -->|initializeCell호출| B[Cell 초기화]
    B -->|bind호출| C[썸네일 제외 나머지 정보들 동기적으로 세팅]
    C -->|ImageLoader 의 patch호출, 이때의 index 저장| D([썸네일 가져오는 중...])
    D --> F[썸네일 가져옴]
    F --> G[썸네일 요청했던 때의 index에 해당하는 cell 이 화면에 있으면 이미지 세팅]
    C --> E[화면에 Cell 업데이트됨]
```


## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 생각해주세요!! -->

- [x] 변경 사항을 적용하고 테스트를 해봤나요?
- [x] [Code Convention](https://own-exhibition.notion.site/Code-Style-de19f16db2a544d08da60335f51c9912)을 준수했나요?
