### PR TITLE
탭바에서 내정보를 눌렀을 때 로그인 여부에따라 로그인 화면으로 이동하도록 구현

### DIFF
--- a/own-exhibition.xcodeproj/project.pbxproj
+++ b/own-exhibition.xcodeproj/project.pbxproj
@@ -22,6 +22,11 @@
 		DA170D4C291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA170D4B291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift */; };
 		DA41F6DF29100FFB008ED455 /* ExhibitionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA41F6DE29100FFB008ED455 /* ExhibitionRepository.swift */; };
 		DA42DD7B29226AB700094733 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA42DD7A29226AB700094733 /* UIImage+.swift */; };
+		DA42DD922923276F00094733 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA42DD912923276F00094733 /* LoginViewController.swift */; };
+		DA42DD942923277600094733 /* Login.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA42DD932923277600094733 /* Login.storyboard */; };
+		DA42DD962923277C00094733 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA42DD952923277C00094733 /* LoginViewModel.swift */; };
+		DA42DD982923278300094733 /* LoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA42DD972923278300094733 /* LoginCoordinator.swift */; };
+		DA739DD7292333C4003AEE4C /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DD6292333C4003AEE4C /* MyPageCoordinator.swift */; };
 		DAAFB256291A90B7007A8DF0 /* CALayer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAFB255291A90B7007A8DF0 /* CALayer+.swift */; };
 		E805F2AC2901528000D75FA3 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805F2AB2901528000D75FA3 /* HomeViewModel.swift */; };
 		E805F2AE290152A200D75FA3 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E805F2AD290152A200D75FA3 /* ViewModelType.swift */; };
@@ -79,6 +84,11 @@
 		DA170D4B291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionDetailCoordinator.swift; sourceTree = "<group>"; };
 		DA41F6DE29100FFB008ED455 /* ExhibitionRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionRepository.swift; sourceTree = "<group>"; };
 		DA42DD7A29226AB700094733 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
+		DA42DD912923276F00094733 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		DA42DD932923277600094733 /* Login.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Login.storyboard; sourceTree = "<group>"; };
+		DA42DD952923277C00094733 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		DA42DD972923278300094733 /* LoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCoordinator.swift; sourceTree = "<group>"; };
+		DA739DD6292333C4003AEE4C /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		DAAFB255291A90B7007A8DF0 /* CALayer+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+.swift"; sourceTree = "<group>"; };
 		E5E722FB0506808F9D489C0D /* Pods-own-exhibition.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-own-exhibition.release.xcconfig"; path = "Target Support Files/Pods-own-exhibition/Pods-own-exhibition.release.xcconfig"; sourceTree = "<group>"; };
 		E5EC47743B90C6D64BDFE17B /* Pods_own_exhibitionTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_own_exhibitionTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -154,6 +164,7 @@
 				68B54470290D2B8F00A9F71A /* MyPage.storyboard */,
 				68B54472290D2BA000A9F71A /* MyPageViewController.swift */,
 				68B54474290D2BB500A9F71A /* MyPageViewModel.swift */,
+				DA739DD6292333C4003AEE4C /* MyPageCoordinator.swift */,
 			);
 			path = MyPage;
 			sourceTree = "<group>";
@@ -298,6 +309,10 @@
 		E8BABA5228FE4E2E009482E4 /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				DA42DD932923277600094733 /* Login.storyboard */,
+				DA42DD912923276F00094733 /* LoginViewController.swift */,
+				DA42DD952923277C00094733 /* LoginViewModel.swift */,
+				DA42DD972923278300094733 /* LoginCoordinator.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -512,6 +527,7 @@
 			files = (
 				DA170D462910EB2100BFC7B1 /* ExhibitionDetail.storyboard in Resources */,
 				E8A1ADE528EBDD1800A360FA /* LaunchScreen.storyboard in Resources */,
+				DA42DD942923277600094733 /* Login.storyboard in Resources */,
 				E8A1ADE228EBDD1800A360FA /* Assets.xcassets in Resources */,
 				E805F2C32901977300D75FA3 /* ExhibitionTableViewCell.xib in Resources */,
 				E8A1ADE028EBDD1600A360FA /* Home.storyboard in Resources */,
@@ -646,6 +662,7 @@
 				E805F2C72901AAFC00D75FA3 /* Reusable.swift in Sources */,
 				DA170D442910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift in Sources */,
 				E8A1ADDD28EBDD1600A360FA /* HomeViewController.swift in Sources */,
+				DA42DD922923276F00094733 /* LoginViewController.swift in Sources */,
 				DA170D4A29111B5300BFC7B1 /* HomeCoordinator.swift in Sources */,
 				E8A1ADD928EBDD1600A360FA /* AppDelegate.swift in Sources */,
 				DA170D482910EB3600BFC7B1 /* ExhibitionDetailViewController.swift in Sources */,
@@ -659,9 +676,12 @@
 				DAAFB256291A90B7007A8DF0 /* CALayer+.swift in Sources */,
 				DA0A881F291D424500E9AE43 /* ImageLoader.swift in Sources */,
 				E805F2AE290152A200D75FA3 /* ViewModelType.swift in Sources */,
+				DA739DD7292333C4003AEE4C /* MyPageCoordinator.swift in Sources */,
+				DA42DD982923278300094733 /* LoginCoordinator.swift in Sources */,
 				DA170D4C291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift in Sources */,
 				E805F2BA2901944800D75FA3 /* Exhibition.swift in Sources */,
 				E805F2AC2901528000D75FA3 /* HomeViewModel.swift in Sources */,
+				DA42DD962923277C00094733 /* LoginViewModel.swift in Sources */,
 				DA42DD7B29226AB700094733 /* UIImage+.swift in Sources */,
 				DA41F6DF29100FFB008ED455 /* ExhibitionRepository.swift in Sources */,
 				68B54475290D2BB500A9F71A /* MyPageViewModel.swift in Sources */,

--- a/own-exhibition/Presentation/Common/TabBarController/MainTabBarController.swift
+++ b/own-exhibition/Presentation/Common/TabBarController/MainTabBarController.swift
@@ -9,28 +9,69 @@ import UIKit
 
 final class MainTabBarController: UITabBarController {
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        let homeNavigationController: UINavigationController = .init()
-        homeNavigationController.tabBarItem = .init(
+    private let homeNavigationController: UINavigationController = {
+        let nc: UINavigationController = .init()
+        nc.tabBarItem = .init(
             title: "홈",
             image: UIImage.init(systemName: "house"),
             selectedImage: UIImage.init(systemName: "house.fill")
         )
-        let homeCoordinator: HomeCoordinator = .init(navigationController: homeNavigationController)
-        homeCoordinator.start()
-        
-        let myPageVC = MyPageViewController.instantiate(withStoryboardName: "MyPage")
-        let myPageTabBarItem = UITabBarItem.init(
+        return nc
+    }()
+    
+    private let myPageNavigationController: UINavigationController = {
+        let nc: UINavigationController = .init()
+        nc.tabBarItem = .init(
             title: "내정보",
             image: UIImage.init(systemName: "person"),
             selectedImage: UIImage.init(systemName: "person.fill")
         )
-        myPageVC.tabBarItem = myPageTabBarItem
+        return nc
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.delegate = self
         
-        self.viewControllers = [homeNavigationController, myPageVC]
+        let homeCoordinator: HomeCoordinator = .init(navigationController: homeNavigationController)
+        homeCoordinator.start()
+        
+        let myPageCoordinator: MyPageCoordinator = .init(navigationController: myPageNavigationController)
+        myPageCoordinator.start()
+        
+        self.viewControllers = [
+            homeNavigationController,
+            myPageNavigationController,
+        ]
         
         self.tabBar.backgroundColor = .systemGray6
+    }
+}
+
+extension MainTabBarController: UITabBarControllerDelegate {
+    
+    func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        if viewController == myPageNavigationController {
+            // FIXME: 로그인 되어있는지 확인하는 로직 추가
+            let isLoggedIn: Bool = false
+            
+            if isLoggedIn {
+                return true
+            } else {
+                guard let presentingNC = tabBarController.selectedViewController as? UINavigationController else {
+                    return false
+                }
+                let loginCoordinator: LoginCoordinator = .init(
+                    navigationController: presentingNC,
+                    tabBarController: tabBarController,
+                    targetViewController: viewController
+                )
+                loginCoordinator.start()
+                
+                return false
+            }
+        }
+        
+        return true
     }
 }

--- a/own-exhibition/Presentation/Scenes/Login/Login.storyboard
+++ b/own-exhibition/Presentation/Scenes/Login/Login.storyboard
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Login View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="LoginViewController" id="Y6W-OH-hqX" customClass="LoginViewController" customModule="own_exhibition" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GXi-Xb-Dse">
+                                <rect key="frame" x="161" y="467" width="69" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="로그인"/>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kn3-SI-w08">
+                                <rect key="frame" x="300" y="115" width="36" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="X"/>
+                                <connections>
+                                    <action selector="didTapDismissButton:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="TfG-Ms-4FT"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <connections>
+                        <outlet property="loginButton" destination="GXi-Xb-Dse" id="2vd-Gj-HRL"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="117" y="-2"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/own-exhibition/Presentation/Scenes/Login/LoginCoordinator.swift
+++ b/own-exhibition/Presentation/Scenes/Login/LoginCoordinator.swift
@@ -1,0 +1,43 @@
+//
+//  LoginCoordinator.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/11/15.
+//
+
+import UIKit
+
+final class LoginCoordinator {
+    
+    private let navigationController: UINavigationController
+    private let storyboardName: String = "Login"
+    private let tabBarController: UITabBarController
+    private let targetViewController: UIViewController
+    
+    init(
+        navigationController: UINavigationController,
+        tabBarController: UITabBarController,
+        targetViewController: UIViewController
+    ) {
+        self.navigationController = navigationController
+        self.tabBarController = tabBarController
+        self.targetViewController = targetViewController
+    }
+    
+    func start() {
+        let loginVC: LoginViewController = .instantiate(withStoryboardName: storyboardName)
+        let loginVM: LoginViewModel = .init(coordinator: self)
+        loginVC.setViewModel(by: loginVM)
+        
+        let presentedNC: UINavigationController = .init()
+        presentedNC.pushViewController(loginVC, animated: false)
+        presentedNC.modalTransitionStyle = .crossDissolve
+        presentedNC.modalPresentationStyle = .fullScreen
+        navigationController.present(presentedNC, animated: false)
+    }
+    
+    func toTargetViewController() {
+        navigationController.dismiss(animated: false)
+        tabBarController.selectedViewController = targetViewController
+    }
+}

--- a/own-exhibition/Presentation/Scenes/Login/LoginViewController.swift
+++ b/own-exhibition/Presentation/Scenes/Login/LoginViewController.swift
@@ -1,0 +1,48 @@
+//
+//  LoginViewController.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/11/15.
+//
+
+import UIKit
+import RxSwift
+
+final class LoginViewController: UIViewController {
+    
+    private var disposeBag: DisposeBag = .init()
+    
+    private var viewModel: LoginViewModel!
+    
+    @IBOutlet weak var loginButton: UIButton!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        bindViewModel()
+    }
+    
+    func bindViewModel() {
+        let input = LoginViewModel.Input.init(
+            login: loginButton.rx.tap.asSignal(),
+            id: .of("").asDriver(),
+            password: .of("").asDriver()
+        )
+        let output = viewModel.transform(input: input)
+        
+        output.isLoggedIn
+            .drive(onNext: { isLoggedIn in
+                if isLoggedIn == false {
+                    print("아이디 혹은 비밀번호가 올바르지 않습니다.")
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func setViewModel(by viewModel: LoginViewModel) {
+        self.viewModel = viewModel
+    }
+    
+    @IBAction func didTapDismissButton(_ sender: UIButton) {
+        self.dismiss(animated: false)
+    }
+}

--- a/own-exhibition/Presentation/Scenes/Login/LoginViewModel.swift
+++ b/own-exhibition/Presentation/Scenes/Login/LoginViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  LoginViewModel.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/11/15.
+//
+
+import RxSwift
+import RxCocoa
+
+final class LoginViewModel: ViewModelType {
+    
+    struct Input {
+        let login: Signal<Void>
+        let id: Driver<String>
+        let password: Driver<String>
+    }
+    
+    struct Output {
+        let isLoggedIn: Driver<Bool>
+    }
+    
+    private let coordinator: LoginCoordinator
+    
+    init(coordinator: LoginCoordinator) {
+        self.coordinator = coordinator
+    }
+    
+    func transform(input: Input) -> Output {
+        let idAndPassword = Driver.combineLatest(input.id, input.password)
+        
+        let isLoggedIn = input.login
+            .withLatestFrom(idAndPassword)
+            .flatMapFirst { id, password in
+                // FIXME: 로그인 처리 로직 추가
+                return .of(true).asDriver()
+            }
+            .do(onNext: { isLoggedIn in
+                if isLoggedIn == true {
+                    self.coordinator.toTargetViewController()
+                }
+            })
+                
+        return .init(
+            isLoggedIn: isLoggedIn
+        )
+    }
+}

--- a/own-exhibition/Presentation/Scenes/MyPage/MyPageCoordinator.swift
+++ b/own-exhibition/Presentation/Scenes/MyPage/MyPageCoordinator.swift
@@ -1,0 +1,25 @@
+//
+//  MyPageCoordinator.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/11/15.
+//
+
+import UIKit
+
+final class MyPageCoordinator {
+    
+    private let navigationController: UINavigationController
+    private let storyboardName: String = "MyPage"
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        let myPageVC: MyPageViewController = .instantiate(withStoryboardName: storyboardName)
+        let myPageVM: MyPageViewModel = .init(myPageCoordinator: self)
+        myPageVC.setViewModel(by: myPageVM)
+        navigationController.pushViewController(myPageVC, animated: false)
+    }
+}

--- a/own-exhibition/Presentation/Scenes/MyPage/MyPageViewController.swift
+++ b/own-exhibition/Presentation/Scenes/MyPage/MyPageViewController.swift
@@ -6,9 +6,14 @@
 //
 
 import UIKit
+import RxSwift
 
-class MyPageViewController: UIViewController {
+final class MyPageViewController: UIViewController {
    
+    private var disposeBag: DisposeBag = .init()
+    
+    private var viewModel: MyPageViewModel!
+    
     //마이페이지 View
     @IBOutlet weak var EmailView: UIView!
     @IBOutlet weak var NameView: UIView!
@@ -22,6 +27,7 @@ class MyPageViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        bindViewModel()
         
         //마이페이지 View 사이 줄
         EmailView.layer.addBorder([.bottom], color: UIColor.darkGray, width: 1.0)
@@ -33,5 +39,14 @@ class MyPageViewController: UIViewController {
         WithdrawalButton.layer.addBorder([.bottom], color: UIColor.darkGray, width: 1.0)
     }
     
+    func bindViewModel() {
+        let input = MyPageViewModel.Input.init()
+        let output = viewModel.transform(input: input)
+
+        _ = output
+    }
     
+    func setViewModel(by viewModel: MyPageViewModel) {
+        self.viewModel = viewModel
+    }
 }

--- a/own-exhibition/Presentation/Scenes/MyPage/MyPageViewModel.swift
+++ b/own-exhibition/Presentation/Scenes/MyPage/MyPageViewModel.swift
@@ -6,8 +6,9 @@
 //
 
 import RxSwift
+import RxCocoa
 
-class MyPageViewModel: ViewModelType {
+final class MyPageViewModel: ViewModelType {
     
     struct Input {
         
@@ -15,6 +16,12 @@ class MyPageViewModel: ViewModelType {
     
     struct Output {
         
+    }
+    
+    private let myPageCoordinator: MyPageCoordinator
+    
+    init(myPageCoordinator: MyPageCoordinator) {
+        self.myPageCoordinator = myPageCoordinator
     }
     
     func transform(input: Input) -> Output {


### PR DESCRIPTION
## 부가 설명
<!-- 필요 시 작성 -->
- 내정보 탭 터치 시, delegate 에서 터치했을때 탭을 기억하여 로그인 미완료 시 이전 탭으로 이동하도록 구현
- 로그인 완료 or 로그인 상태일 시, 내정보 화면으로 넘어가도록 구현

## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->
<img src="https://user-images.githubusercontent.com/81426024/202098889-19fd3236-b802-4561-b20e-ff920ee906ed.gif" width=300>


## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 생각해주세요!! -->

- [x] 변경 사항을 적용하고 테스트를 해봤나요?
- [x] [Code Convention](https://own-exhibition.notion.site/Code-Style-de19f16db2a544d08da60335f51c9912)을 준수했나요?
