### PR TITLE
[Feat] 탭바에 찜 목록 추가 & 찜 목록 화면 구현

### DIFF
--- a/own-exhibition/Presentation/Common/TabBarController/MainTabBarController.swift
+++ b/own-exhibition/Presentation/Common/TabBarController/MainTabBarController.swift
@@ -19,6 +19,16 @@ final class MainTabBarController: UITabBarController {
         return nc
     }()
     
+    private let wishListNavigationController: UINavigationController = {
+        let nc: UINavigationController = .init()
+        nc.tabBarItem = .init(
+            title: "찜목록",
+            image: UIImage.init(systemName: "heart"),
+            selectedImage: UIImage.init(systemName: "heart.fill")
+        )
+        return nc
+    }()
+    
     private let myPageNavigationController: UINavigationController = {
         let nc: UINavigationController = .init()
         nc.tabBarItem = .init(
@@ -36,11 +46,15 @@ final class MainTabBarController: UITabBarController {
         let homeCoordinator: HomeCoordinator = .init(navigationController: homeNavigationController)
         homeCoordinator.start()
         
+        let wishListCoordinator: WishListCoordinator = .init(navigationController: wishListNavigationController)
+        wishListCoordinator.start()
+        
         let myPageCoordinator: MyPageCoordinator = .init(navigationController: myPageNavigationController)
         myPageCoordinator.start()
         
         self.viewControllers = [
             homeNavigationController,
+            wishListNavigationController,
             myPageNavigationController,
         ]
         
@@ -51,7 +65,7 @@ final class MainTabBarController: UITabBarController {
 extension MainTabBarController: UITabBarControllerDelegate {
     
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
-        if viewController == myPageNavigationController {
+        if viewController == myPageNavigationController || viewController == wishListNavigationController {
             // FIXME: 로그인 되어있는지 확인하는 로직 추가
             let isLoggedIn: Bool = false
             

--- a/own-exhibition/Presentation/Scenes/WishList/WishList.storyboard
+++ b/own-exhibition/Presentation/Scenes/WishList/WishList.storyboard
@@ -16,9 +16,32 @@
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="전시회 제목으로 검색" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nHI-Hs-fOo">
+                                <rect key="frame" x="30" y="57" width="330" height="34"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="ewH-3T-pHq">
+                                <rect key="frame" x="0.0" y="101" width="390" height="709"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </tableView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="ewH-3T-pHq" firstAttribute="top" secondItem="nHI-Hs-fOo" secondAttribute="bottom" constant="10" id="3mm-m3-iUx"/>
+                            <constraint firstItem="nHI-Hs-fOo" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="10" id="LUE-Lc-JBf"/>
+                            <constraint firstItem="nHI-Hs-fOo" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leading" constant="30" id="TgG-hM-7WQ"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="nHI-Hs-fOo" secondAttribute="trailing" constant="30" id="itt-3T-8dk"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="ewH-3T-pHq" secondAttribute="trailing" id="oXL-RF-eiy"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="ewH-3T-pHq" secondAttribute="bottom" id="yM4-bS-hj4"/>
+                            <constraint firstItem="ewH-3T-pHq" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="z9b-8p-ZDj"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="exhibitionTableView" destination="ewH-3T-pHq" id="axY-Kj-7TB"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/own-exhibition/Presentation/Scenes/WishList/WishListCoordinator.swift
+++ b/own-exhibition/Presentation/Scenes/WishList/WishListCoordinator.swift
@@ -5,8 +5,27 @@
 //  Created by Jaewon Yun on 2022/11/23.
 //
 
-import Foundation
+import UIKit
 
 final class WishListCoordinator {
+    
+    private let navigationController: UINavigationController
+    private let storyboardName: String = "WishList"
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        let wishListVC: WishListViewController = .instantiate(withStoryboardName: storyboardName)
+        let wishListVM: WishListViewModel = .init(coordinator: self, exhibitionRepository: .init())
+        wishListVC.setViewModel(by: wishListVM)
+        navigationController.pushViewController(wishListVC, animated: false)
+    }
+    
+    func toDetail(with exhibition: Exhibition) {
+        let exhibitionDetailCoordinator: ExhibitionDetailCoordinator = .init(navigationController: navigationController)
+        exhibitionDetailCoordinator.start(with: exhibition)
+    }
     
 }

--- a/own-exhibition/Presentation/Scenes/WishList/WishListViewController.swift
+++ b/own-exhibition/Presentation/Scenes/WishList/WishListViewController.swift
@@ -6,10 +6,77 @@
 //
 
 import UIKit
+import RxSwift
 
 final class WishListViewController: UIViewController {
     
+    private let disposeBag = DisposeBag.init()
+    
+    @IBOutlet weak var exhibitionTableView: UITableView!
+    
+    private var viewModel: WishListViewModel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        bindViewModel()
+        registerCell()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        configureNavigationBar()
+    }
+    
+    func setViewModel(by viewModel: WishListViewModel) {
+        self.viewModel = viewModel
+    }
+}
+
+// MARK: - Private Functions
+
+private extension WishListViewController {
+    
+    func bindViewModel() {
+        let viewWillAppear = self.rx.sentMessage(#selector(self.viewWillAppear(_:)))
+            .map { _ in }
+        
+        let input = WishListViewModel.Input.init(
+            viewWillAppear: viewWillAppear.asSignal(onErrorSignalWith: .empty()),
+            selection: exhibitionTableView.rx.itemSelected.asDriver()
+        )
+        let output = viewModel.transform(input: input)
+        
+        output.exhibitions
+            .drive(
+                exhibitionTableView.rx.items(
+                    cellIdentifier: ExhibitionTableViewCell.id,
+                    cellType: ExhibitionTableViewCell.self
+                )
+            ) { index, exhibition, cell in
+                let indexPath: IndexPath = .init(row: index, section: 0)
+                cell.initializeCell()
+                cell.bind(exhibition, withFetchedImage: { [indexPath] thumbnailImage in
+                    DispatchQueue.main.async {
+                        let currentCell = self.exhibitionTableView.cellForRow(at: indexPath) as? ExhibitionTableViewCell
+                        currentCell?.setThumbnailImage(thumbnailImage)
+                    }
+                })
+            }
+            .disposed(by: disposeBag)
+        
+        output.selectedExhibition
+            .drive()
+            .disposed(by: disposeBag)
+    }
+    
+    func registerCell() {
+        let nibName = ExhibitionTableViewCell.id
+        let nib = UINib.init(nibName: nibName, bundle: nil)
+        exhibitionTableView.register(nib, forCellReuseIdentifier: nibName)
+    }
+    
+    func configureNavigationBar() {
+        self.navigationItem.backBarButtonItem = DefaultBackBarButtonItem.init()
+        self.navigationController?.isNavigationBarHidden = true
     }
 }

--- a/own-exhibition/Presentation/Scenes/WishList/WishListViewModel.swift
+++ b/own-exhibition/Presentation/Scenes/WishList/WishListViewModel.swift
@@ -5,19 +5,45 @@
 //  Created by Jaewon Yun on 2022/11/23.
 //
 
-import Foundation
+import RxSwift
+import RxCocoa
 
 final class WishListViewModel: ViewModelType {
     
     struct Input {
-        
+        let viewWillAppear: Signal<Void>
+        let selection: Driver<IndexPath>
     }
     
     struct Output {
-        
+        let exhibitions: Driver<[Exhibition]>
+        let selectedExhibition: Driver<Exhibition>
+    }
+    
+    private let coordinator: WishListCoordinator
+    private let exhibitionRepository: ExhibitionRepository
+    
+    init(coordinator: WishListCoordinator, exhibitionRepository: ExhibitionRepository) {
+        self.coordinator = coordinator
+        self.exhibitionRepository = exhibitionRepository
     }
     
     func transform(input: Input) -> Output {
-        return .init()
+        let exhibitions = input.viewWillAppear
+            .flatMapLatest { _ in
+                // FIXME: 특정 유저의 찜 목록 가져오는 로직으로 변경
+                return self.exhibitionRepository.getExhibitions()
+                    .asDriver(onErrorJustReturn: [])
+            }
+        let selectedExhibition = input.selection
+            .withLatestFrom(exhibitions) { indexPath, exhibitions -> Exhibition in
+                return exhibitions[indexPath.row]
+            }
+            .do(onNext: coordinator.toDetail)
+        
+        return .init(
+            exhibitions: exhibitions,
+            selectedExhibition: selectedExhibition
+        )
     }
 }


### PR DESCRIPTION
## 부가 설명
<!-- 필요 시 작성 -->
- 현재 디자인 상으로는 홈 화면하고 똑같으니 거의 같은 코드를 사용했고 데이터를 불러오는 로직만 변경하면 될것같습니다.(FIXME 태그 추가해놓음)
- 찜 목록도 로그인이 필요하므로 로그인 확인 로직을 타게 했습니다.

## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 생각해주세요!! -->

- [x] 변경 사항을 적용하고 테스트를 해봤나요?
- [x] [Code Convention](https://own-exhibition.notion.site/Code-Style-de19f16db2a544d08da60335f51c9912)을 준수했나요?
