### PR TITLE
전시회 테이블 뷰 페이징 구현

### DIFF
--- a/own-exhibition.xcodeproj/project.pbxproj
+++ b/own-exhibition.xcodeproj/project.pbxproj
@@ -38,10 +38,12 @@
 		DA6BCE58292E24870059E95D /* WishListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6BCE57292E24870059E95D /* WishListViewController.swift */; };
 		DA6BCE5A292E24960059E95D /* WishListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6BCE59292E24960059E95D /* WishListCoordinator.swift */; };
 		DA7201FE2932292900A69519 /* ExhibitionSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7201FD2932292900A69519 /* ExhibitionSearchBar.swift */; };
+		DA72020529345B3200A69519 /* ExhibitionPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA72020429345B3200A69519 /* ExhibitionPage.swift */; };
+		DA7202092934624700A69519 /* ExhibitionResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7202082934624700A69519 /* ExhibitionResponseDTO.swift */; };
 		DA72020D2934E6C000A69519 /* UIScrollView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA72020C2934E6C000A69519 /* UIScrollView+Rx.swift */; };
 		DA739DD7292333C4003AEE4C /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DD6292333C4003AEE4C /* MyPageCoordinator.swift */; };
 		DA739DF029277D9E003AEE4C /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DEF29277D9E003AEE4C /* NetworkService.swift */; };
-		DA739DF329277F10003AEE4C /* ExhibitionsResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DF229277F10003AEE4C /* ExhibitionsResponseDTO.swift */; };
+		DA739DF329277F10003AEE4C /* ExhibitionPageResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DF229277F10003AEE4C /* ExhibitionPageResponseDTO.swift */; };
 		DA739DF62927807A003AEE4C /* EntityConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DF52927807A003AEE4C /* EntityConvertible.swift */; };
 		DA739DF829278799003AEE4C /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DF729278799003AEE4C /* NetworkError.swift */; };
 		DA739E22292C792E003AEE4C /* SignUpCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739E21292C792E003AEE4C /* SignUpCoordinator.swift */; };
@@ -121,10 +123,12 @@
 		DA6BCE57292E24870059E95D /* WishListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WishListViewController.swift; sourceTree = "<group>"; };
 		DA6BCE59292E24960059E95D /* WishListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WishListCoordinator.swift; sourceTree = "<group>"; };
 		DA7201FD2932292900A69519 /* ExhibitionSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionSearchBar.swift; sourceTree = "<group>"; };
+		DA72020429345B3200A69519 /* ExhibitionPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionPage.swift; sourceTree = "<group>"; };
+		DA7202082934624700A69519 /* ExhibitionResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionResponseDTO.swift; sourceTree = "<group>"; };
 		DA72020C2934E6C000A69519 /* UIScrollView+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Rx.swift"; sourceTree = "<group>"; };
 		DA739DD6292333C4003AEE4C /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		DA739DEF29277D9E003AEE4C /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
-		DA739DF229277F10003AEE4C /* ExhibitionsResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionsResponseDTO.swift; sourceTree = "<group>"; };
+		DA739DF229277F10003AEE4C /* ExhibitionPageResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionPageResponseDTO.swift; sourceTree = "<group>"; };
 		DA739DF52927807A003AEE4C /* EntityConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityConvertible.swift; sourceTree = "<group>"; };
 		DA739DF729278799003AEE4C /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		DA739E21292C792E003AEE4C /* SignUpCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpCoordinator.swift; sourceTree = "<group>"; };
@@ -251,7 +255,8 @@
 		DA739DF129277EBF003AEE4C /* ResponseDTO */ = {
 			isa = PBXGroup;
 			children = (
-				DA739DF229277F10003AEE4C /* ExhibitionsResponseDTO.swift */,
+				DA739DF229277F10003AEE4C /* ExhibitionPageResponseDTO.swift */,
+				DA7202082934624700A69519 /* ExhibitionResponseDTO.swift */,
 			);
 			path = ResponseDTO;
 			sourceTree = "<group>";
@@ -297,6 +302,7 @@
 			isa = PBXGroup;
 			children = (
 				E805F2B92901944800D75FA3 /* Exhibition.swift */,
+				DA72020429345B3200A69519 /* ExhibitionPage.swift */,
 				6874D54A291C2A6E00465398 /* PersonalInfo.swift */,
 				DA41F6DD290F845D008ED455 /* Utils */,
 			);
@@ -760,6 +766,7 @@
 				E805F2C72901AAFC00D75FA3 /* Reusable.swift in Sources */,
 				DA170D442910EB0F00BFC7B1 /* ExhibitionDetailViewModel.swift in Sources */,
 				E8A1ADDD28EBDD1600A360FA /* HomeViewController.swift in Sources */,
+				DA72020529345B3200A69519 /* ExhibitionPage.swift in Sources */,
 				DA42DD922923276F00094733 /* LoginViewController.swift in Sources */,
 				DA170D4A29111B5300BFC7B1 /* HomeCoordinator.swift in Sources */,
 				DA6BCE54292DFA400059E95D /* WishListViewModel.swift in Sources */,
@@ -795,8 +802,9 @@
 				E805F2AC2901528000D75FA3 /* HomeViewModel.swift in Sources */,
 				DA72020D2934E6C000A69519 /* UIScrollView+Rx.swift in Sources */,
 				6874D558292103C500465398 /* ChangeInfoViewModel.swift in Sources */,
-				DA739DF329277F10003AEE4C /* ExhibitionsResponseDTO.swift in Sources */,
+				DA739DF329277F10003AEE4C /* ExhibitionPageResponseDTO.swift in Sources */,
 				DA42DD962923277C00094733 /* LoginViewModel.swift in Sources */,
+				DA7202092934624700A69519 /* ExhibitionResponseDTO.swift in Sources */,
 				DA42DD7B29226AB700094733 /* UIImage+.swift in Sources */,
 				DA41F6DF29100FFB008ED455 /* ExhibitionRepository.swift in Sources */,
 				DA739E28292C7968003AEE4C /* SignUpViewModel.swift in Sources */,

--- a/own-exhibition.xcodeproj/project.pbxproj
+++ b/own-exhibition.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		DA6BCE58292E24870059E95D /* WishListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6BCE57292E24870059E95D /* WishListViewController.swift */; };
 		DA6BCE5A292E24960059E95D /* WishListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6BCE59292E24960059E95D /* WishListCoordinator.swift */; };
 		DA7201FE2932292900A69519 /* ExhibitionSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7201FD2932292900A69519 /* ExhibitionSearchBar.swift */; };
+		DA72020D2934E6C000A69519 /* UIScrollView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA72020C2934E6C000A69519 /* UIScrollView+Rx.swift */; };
 		DA739DD7292333C4003AEE4C /* MyPageCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DD6292333C4003AEE4C /* MyPageCoordinator.swift */; };
 		DA739DF029277D9E003AEE4C /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DEF29277D9E003AEE4C /* NetworkService.swift */; };
 		DA739DF329277F10003AEE4C /* ExhibitionsResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA739DF229277F10003AEE4C /* ExhibitionsResponseDTO.swift */; };
@@ -120,6 +121,7 @@
 		DA6BCE57292E24870059E95D /* WishListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WishListViewController.swift; sourceTree = "<group>"; };
 		DA6BCE59292E24960059E95D /* WishListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WishListCoordinator.swift; sourceTree = "<group>"; };
 		DA7201FD2932292900A69519 /* ExhibitionSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionSearchBar.swift; sourceTree = "<group>"; };
+		DA72020C2934E6C000A69519 /* UIScrollView+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Rx.swift"; sourceTree = "<group>"; };
 		DA739DD6292333C4003AEE4C /* MyPageCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageCoordinator.swift; sourceTree = "<group>"; };
 		DA739DEF29277D9E003AEE4C /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		DA739DF229277F10003AEE4C /* ExhibitionsResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitionsResponseDTO.swift; sourceTree = "<group>"; };
@@ -268,6 +270,7 @@
 				68A26164290DB4D10036DF42 /* UIView+.swift */,
 				DAAFB255291A90B7007A8DF0 /* CALayer+.swift */,
 				DA42DD7A29226AB700094733 /* UIImage+.swift */,
+				DA72020C2934E6C000A69519 /* UIScrollView+Rx.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -790,6 +793,7 @@
 				DA170D4C291120F200BFC7B1 /* ExhibitionDetailCoordinator.swift in Sources */,
 				E805F2BA2901944800D75FA3 /* Exhibition.swift in Sources */,
 				E805F2AC2901528000D75FA3 /* HomeViewModel.swift in Sources */,
+				DA72020D2934E6C000A69519 /* UIScrollView+Rx.swift in Sources */,
 				6874D558292103C500465398 /* ChangeInfoViewModel.swift in Sources */,
 				DA739DF329277F10003AEE4C /* ExhibitionsResponseDTO.swift in Sources */,
 				DA42DD962923277C00094733 /* LoginViewModel.swift in Sources */,

--- a/own-exhibition/Domain/Entities/ExhibitionPage.swift
+++ b/own-exhibition/Domain/Entities/ExhibitionPage.swift
@@ -1,0 +1,14 @@
+//
+//  ExhibitionPage.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/11/28.
+//
+
+import Foundation
+
+struct ExhibitionPage {
+    let currentPage: Int
+    let lastPage: Int
+    let exhibitions: [Exhibition]
+}

--- a/own-exhibition/Network/ResponseDTO/ExhibitionPageResponseDTO.swift
+++ b/own-exhibition/Network/ResponseDTO/ExhibitionPageResponseDTO.swift
@@ -1,0 +1,31 @@
+//
+//  ExhibitionPageResponseDTO.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/11/18.
+//
+
+import Foundation
+
+final class ExhibitionPageResponseDTO: Decodable {
+    let currentPage: Int
+    let lastPage: Int
+    let data: [ExhibitionResponseDTO]
+    
+    enum CodingKeys: String, CodingKey {
+        case currentPage = "current_page"
+        case lastPage = "last_page"
+        case data
+    }
+}
+
+extension ExhibitionPageResponseDTO {
+    
+    func toEntity() -> ExhibitionPage {
+        return .init(
+            currentPage: currentPage,
+            lastPage: lastPage,
+            exhibitions: data.map { $0.toEntity() }
+        )
+    }
+}

--- a/own-exhibition/Network/ResponseDTO/ExhibitionResponseDTO.swift
+++ b/own-exhibition/Network/ResponseDTO/ExhibitionResponseDTO.swift
@@ -1,15 +1,11 @@
 //
-//  ExhibitionsResponseDTO.swift
+//  ExhibitionResponseDTO.swift
 //  own-exhibition
 //
-//  Created by Jaewon Yun on 2022/11/18.
+//  Created by Jaewon Yun on 2022/11/28.
 //
 
 import Foundation
-
-final class ExhibitionsResponseDTO: Decodable {
-    let data: [ExhibitionResponseDTO]
-}
 
 final class ExhibitionResponseDTO: Decodable {
     let seq: String
@@ -74,13 +70,13 @@ extension ExhibitionResponseDTO: EntityConvertible {
             startDate: {
                 let startDate: String = startDate
                 let formatter = DateFormatter()
-                formatter.dateFormat = "yyyyMMdd"
+                formatter.dateFormat = "yyyy-MM-dd"
                 return formatter.date(from: startDate)!
             }(),
             endDate: {
                 let startDate: String = endDate
                 let formatter = DateFormatter()
-                formatter.dateFormat = "yyyyMMdd"
+                formatter.dateFormat = "yyyy-MM-dd"
                 return formatter.date(from: startDate)!
             }(),
             location: .init(lon: Double(gpsX) ?? 0, lat: Double(gpsY) ?? 0),

--- a/own-exhibition/Presentation/Scenes/Home/HomeViewController.swift
+++ b/own-exhibition/Presentation/Scenes/Home/HomeViewController.swift
@@ -44,7 +44,8 @@ private extension HomeViewController {
         let input = HomeViewModel.Input.init(
             viewWillAppear: viewWillAppear.asSignal(onErrorSignalWith: .empty()),
             selection: exhibitionTableView.rx.itemSelected.asDriver().throttle(.milliseconds(500), latest: false),
-            searchWord: searchBar.rx.text.orEmpty.asDriver().debounce(.milliseconds(300))
+            searchWord: searchBar.rx.text.orEmpty.asDriver().debounce(.milliseconds(300)),
+            lodingNextPage: exhibitionTableView.rx.didScrollToBottom.asDriver()
         )
         let output = viewModel.transform(input: input)
         

--- a/own-exhibition/Presentation/Scenes/Home/HomeViewModel.swift
+++ b/own-exhibition/Presentation/Scenes/Home/HomeViewModel.swift
@@ -14,6 +14,7 @@ final class HomeViewModel: ViewModelType {
         let viewWillAppear: Signal<Void>
         let selection: Driver<IndexPath>
         let searchWord: Driver<String>
+        let lodingNextPage: Driver<Void>
     }
     
     struct Output {
@@ -24,22 +25,48 @@ final class HomeViewModel: ViewModelType {
     private let coordinator: HomeCoordinator
     private let exhibitionRepository: ExhibitionRepository
     
+    private var currentExhibitionPage: ExhibitionPage = .init(currentPage: 0, lastPage: 1, exhibitions: [])
+    private var currentExhibitions: [Exhibition] = []
+    
     init(coordinator: HomeCoordinator, exhibitionRepository: ExhibitionRepository) {
         self.coordinator = coordinator
         self.exhibitionRepository = exhibitionRepository
     }
     
     func transform(input: Input) -> Output {
-        let exhibitions = Driver.combineLatest(input.viewWillAppear.asDriver(onErrorDriveWith: .empty()), input.searchWord)
-            .flatMapLatest { _, searchWord in
-                if searchWord.isEmpty {
-                    return self.exhibitionRepository.getExhibitions()
-                        .asDriver(onErrorJustReturn: [])
-                } else {
-                    return self.exhibitionRepository.getExhibitions(bySearchWord: searchWord)
-                        .asDriver(onErrorJustReturn: [])
-                }
+        let refreshExhibitions = input.searchWord
+            .flatMapLatest { searchWord in
+                return self.exhibitionRepository.getExhibitions(page: 1, searchWord: searchWord)
+                    .do(onNext: { exhibitionPage in
+                        self.currentExhibitionPage = exhibitionPage
+                        self.currentExhibitions = exhibitionPage.exhibitions
+                    })
+                    .map { $0.exhibitions }
+                    .asDriver(onErrorJustReturn: [])
             }
+        
+        let updatedExhibitions = input.lodingNextPage
+            .withLatestFrom(input.searchWord)
+            .flatMap { searchWord in
+                let nextPage = self.currentExhibitionPage.currentPage + 1
+                
+                if nextPage > self.currentExhibitionPage.lastPage {
+                    return Driver<[Exhibition]>.of(self.currentExhibitions)
+                }
+                
+                return self.exhibitionRepository.getExhibitions(page: nextPage, searchWord: searchWord)
+                    .do(onNext: { exhibitionPage in
+                        self.currentExhibitionPage = exhibitionPage
+                        self.currentExhibitions += exhibitionPage.exhibitions
+                    })
+                    .flatMap { exhibitionPage in
+                        return Driver<[Exhibition]>.of(self.currentExhibitions)
+                    }
+                    .asDriver(onErrorJustReturn: self.currentExhibitions)
+            }
+        
+        let exhibitions = Driver.merge(refreshExhibitions, updatedExhibitions)
+        
         let selectedExhibition = input.selection
             .withLatestFrom(exhibitions) { indexPath, exhibitions -> Exhibition in
                 return exhibitions[indexPath.row]

--- a/own-exhibition/Presentation/Scenes/WishList/WishListViewController.swift
+++ b/own-exhibition/Presentation/Scenes/WishList/WishListViewController.swift
@@ -44,7 +44,8 @@ private extension WishListViewController {
         let input = WishListViewModel.Input.init(
             viewWillAppear: viewWillAppear.asSignal(onErrorSignalWith: .empty()),
             selection: exhibitionTableView.rx.itemSelected.asDriver().throttle(.milliseconds(500), latest: false),
-            searchWord: searchBar.rx.text.orEmpty.asDriver().debounce(.milliseconds(300))
+            searchWord: searchBar.rx.text.orEmpty.asDriver().debounce(.milliseconds(300)),
+            lodingNextPage: exhibitionTableView.rx.didScrollToBottom.asDriver()
         )
         let output = viewModel.transform(input: input)
         

--- a/own-exhibition/Presentation/Scenes/WishList/WishListViewModel.swift
+++ b/own-exhibition/Presentation/Scenes/WishList/WishListViewModel.swift
@@ -14,6 +14,7 @@ final class WishListViewModel: ViewModelType {
         let viewWillAppear: Signal<Void>
         let selection: Driver<IndexPath>
         let searchWord: Driver<String>
+        let lodingNextPage: Driver<Void>
     }
     
     struct Output {
@@ -24,24 +25,51 @@ final class WishListViewModel: ViewModelType {
     private let coordinator: WishListCoordinator
     private let exhibitionRepository: ExhibitionRepository
     
+    private var currentExhibitionPage: ExhibitionPage = .init(currentPage: 0, lastPage: 1, exhibitions: [])
+    private var currentExhibitions: [Exhibition] = []
+    
     init(coordinator: WishListCoordinator, exhibitionRepository: ExhibitionRepository) {
         self.coordinator = coordinator
         self.exhibitionRepository = exhibitionRepository
     }
     
     func transform(input: Input) -> Output {
-        let exhibitions = Driver.combineLatest(input.viewWillAppear.asDriver(onErrorDriveWith: .empty()), input.searchWord)
-            .flatMapLatest { _, searchWord in
-                if searchWord.isEmpty {
-                    // FIXME: 특정 유저의 찜 목록 가져오는 로직으로 변경
-                    return self.exhibitionRepository.getExhibitions()
-                        .asDriver(onErrorJustReturn: [])
-                } else {
-                    // FIXME: 특정 유저의 찜 목록에서 검색하는 로직으로 변경
-                    return self.exhibitionRepository.getExhibitions(bySearchWord: searchWord)
-                        .asDriver(onErrorJustReturn: [])
-                }
+        let refreshExhibitions = input.searchWord
+            .flatMapLatest { searchWord in
+                // FIXME: 특정 유저의 찜 목록 가져오는 함수로 변경
+                return self.exhibitionRepository.getExhibitions(page: 1, searchWord: searchWord)
+                    .do(onNext: { exhibitionPage in
+                        self.currentExhibitionPage = exhibitionPage
+                        self.currentExhibitions = exhibitionPage.exhibitions
+                    })
+                    .map { $0.exhibitions }
+                    .asDriver(onErrorJustReturn: [])
             }
+        
+        let updatedExhibitions = input.lodingNextPage
+            .withLatestFrom(input.searchWord)
+            .flatMap { searchWord in
+                let nextPage = self.currentExhibitionPage.currentPage + 1
+                
+                if nextPage > self.currentExhibitionPage.lastPage {
+                    return Driver<[Exhibition]>.of(self.currentExhibitions)
+                }
+                
+                // FIXME: 특정 유저의 찜 목록 가져오는 함수로 변경
+                return self.exhibitionRepository.getExhibitions(page: nextPage, searchWord: searchWord)
+                    .do(onNext: { exhibitionPage in
+                        self.currentExhibitionPage = exhibitionPage
+                        self.currentExhibitions += exhibitionPage.exhibitions
+                    })
+                    .flatMap { exhibitionPage in
+                        return Driver<[Exhibition]>.of(self.currentExhibitions)
+                    }
+                    .asDriver(onErrorJustReturn: self.currentExhibitions)
+            }
+        
+        let exhibitions = Driver.merge(refreshExhibitions, updatedExhibitions)
+        
+        
         let selectedExhibition = input.selection
             .withLatestFrom(exhibitions) { indexPath, exhibitions -> Exhibition in
                 return exhibitions[indexPath.row]

--- a/own-exhibition/Repositories/ExhibitionRepository.swift
+++ b/own-exhibition/Repositories/ExhibitionRepository.swift
@@ -9,18 +9,14 @@ import RxSwift
 
 final class ExhibitionRepository {
     
-    private let networkService: NetworkService<ExhibitionsResponseDTO> = .init()
+    private let networkService: NetworkService<ExhibitionPageResponseDTO> = .init()
     
-    func getExhibitions() -> Observable<[Exhibition]> {
-        let path: String = "exhibition"
+    // TODO: 서버 검색 API 구현되면 검색어 쿼리 추가
+    func getExhibitions(page: Int, searchWord: String) -> Observable<ExhibitionPage> {
+        let path: String = "exhibition?page=\(page)"
         return networkService.getItem(byPath: path)
-            .flatMapLatest { exhibitionsResponseDTO -> Observable<[Exhibition]> in
-                return .of(exhibitionsResponseDTO.data.map { $0.toEntity() })
+            .flatMapLatest { exhibitionPageResponseDTO -> Observable<ExhibitionPage> in
+                return .of(exhibitionPageResponseDTO.toEntity())
             }
-    }
-    
-    func getExhibitions(bySearchWord searchWord: String) -> Observable<[Exhibition]> {
-        // TODO: 서버 검색 API 구현되면 호출해서 검색결과 반환
-        return .of([.makeMock1(), .makeMock2()])
     }
 }

--- a/own-exhibition/Utils/Extensions/UIScrollView+Rx.swift
+++ b/own-exhibition/Utils/Extensions/UIScrollView+Rx.swift
@@ -1,0 +1,27 @@
+//
+//  UIScrollView+Rx.swift
+//  own-exhibition
+//
+//  Created by Jaewon Yun on 2022/11/28.
+//
+
+import RxSwift
+import RxCocoa
+
+extension Reactive where Base: UIScrollView {
+    
+    var didScrollToBottom: ControlEvent<Void> {
+        let source = contentOffset.map { contentOffset in
+            let visibleHeight = self.base.frame.height - (self.base.contentInset.top + self.base.contentInset.bottom)
+            let space: CGFloat = 100
+            let y = contentOffset.y + self.base.contentInset.top
+            let threshold = self.base.contentSize.height - visibleHeight - space
+            return y >= threshold
+        }
+            .distinctUntilChanged()
+            .filter { $0 }
+            .map { _ -> Void in }
+
+        return ControlEvent(events: source)
+    }
+}


### PR DESCRIPTION
## 부가 설명
<!-- 필요 시 작성 -->
- 서버가 갑자기 전시회 정보 응답을 페이지 처리를 해서 보내줘서 그에 맞춰서 테이블 뷰도 페이징 처리가 되도록 구현
- ViewModel 이 현재 페이지에 대한 정보를 가지고 있도록 구현
- 날짜 응답 형식도 바뀌어서 수정
- 아 너무 힘들었다...


## 참고 자료
<!-- 필요 시 작성 -->
<!-- 이미지, 링크, 플로우차트 등등 -->
![Simulator Screen Recording - iPhone 12 - 2022-11-28 at 22 23 06](https://user-images.githubusercontent.com/81426024/204290068-8c28ff5d-c9e8-4319-b40a-372caf2f00a5.gif)


## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->
<!-- 꼭!!! 체크하기 전에 다시 한번 생각해주세요!! -->

- [x] 변경 사항을 적용하고 테스트를 해봤나요?
- [x] [Code Convention](https://own-exhibition.notion.site/Code-Style-de19f16db2a544d08da60335f51c9912)을 준수했나요?
